### PR TITLE
[CNIO-536] Create Danogo Adapters

### DIFF
--- a/dexs/danogo/index.ts
+++ b/dexs/danogo/index.ts
@@ -4,6 +4,7 @@ import fetchURL from "../../utils/fetchURL";
 import { DanogoDimensions, DanogoVolumes } from "./types";
 
 const DANOGO_GATEWAY_ENDPOINT = 'https://danogo-gateway.tekoapis.com/api/v1/defillama-dimensions';
+const DANOGO_START_TIMESTAMP = 1685404800 // 30/05/2023
 const CARDANO_COIN_ID = "coingecko:cardano";
 const ADA_DECIMAL = 6;
 
@@ -49,7 +50,7 @@ const adapter: SimpleAdapter = {
     adapter: {
         cardano: {
             fetch: fetchData,
-            start: async () => 0,
+            start: async () => DANOGO_START_TIMESTAMP,
             runAtCurrTime: false,
         }
     }

--- a/dexs/danogo/index.ts
+++ b/dexs/danogo/index.ts
@@ -1,0 +1,58 @@
+import { SimpleAdapter } from "../../adapters/types";
+import { getPrices } from "../../utils/prices";
+import fetchURL from "../../utils/fetchURL";
+import { DanogoDimensions, DanogoVolumes } from "./types";
+
+const DANOGO_GATEWAY_ENDPOINT = 'https://danogo-gateway.tekoapis.com/api/v1/defillama-dimensions';
+const CARDANO_COIN_ID = "coingecko:cardano";
+const ADA_DECIMAL = 6;
+
+const fetchDanogoGatewayData = async (timestamp: number): Promise<DanogoDimensions> => { 
+    const response = await fetchURL(`${DANOGO_GATEWAY_ENDPOINT}?timestamp=${timestamp}`);
+
+    return response.data.data;
+}
+
+const fetchADAprice = async (timestamp: number) => {
+    const price = await getPrices([CARDANO_COIN_ID], timestamp);
+
+    return price[CARDANO_COIN_ID].price;
+}
+
+const lovelaceToUSD = (lovelace: string, price: number) => {
+    const ada = Number(BigInt(lovelace) * BigInt(100) / BigInt(10 ** ADA_DECIMAL)) / 100
+
+    return (ada * price).toString();
+}
+
+const convertDataToUSD = (data: DanogoDimensions, price: number) => {
+    const convertedData: DanogoVolumes = {
+        dailyVolume: lovelaceToUSD(data.dailyVolumeAdaValue, price),
+        totalVolume: lovelaceToUSD(data.totalVolumeAdaValue, price),
+    };
+
+    return convertedData;
+}
+
+const fetchData = async (timestamp: number) => {
+    const dataPromise = fetchDanogoGatewayData(timestamp);
+    const adaPricePromise = fetchADAprice(timestamp);
+    const [data, adaPrice] = await Promise.all([dataPromise, adaPricePromise]);
+
+    return {
+        timestamp: timestamp,
+        ...convertDataToUSD(data, adaPrice)
+    };
+}
+
+const adapter: SimpleAdapter = {
+    adapter: {
+        cardano: {
+            fetch: fetchData,
+            start: async () => 0,
+            runAtCurrTime: false,
+        }
+    }
+};
+
+export default adapter;

--- a/dexs/danogo/types.ts
+++ b/dexs/danogo/types.ts
@@ -1,0 +1,11 @@
+export type DanogoDimensions = {
+    dailyVolumeAdaValue: string,
+    totalVolumeAdaValue: string,
+    dailyFeesAdaValue: string,
+    totalFeesAdaValue: string
+}
+
+export type DanogoVolumes = {
+    dailyVolume: string,
+    totalVolume: string,
+}

--- a/fees/danogo/index.ts
+++ b/fees/danogo/index.ts
@@ -1,0 +1,58 @@
+import { SimpleAdapter } from "../../adapters/types";
+import { getPrices } from "../../utils/prices";
+import fetchURL from "../../utils/fetchURL";
+import { DanogoDimensions, DanogoFees } from "./types";
+
+const DANOGO_GATEWAY_ENDPOINT = 'https://danogo-gateway.tekoapis.com/api/v1/defillama-dimensions';
+const CARDANO_COIN_ID = "coingecko:cardano";
+const ADA_DECIMAL = 6;
+
+const fetchDanogoGatewayData = async (timestamp: number): Promise<DanogoDimensions> => { 
+    const response = await fetchURL(`${DANOGO_GATEWAY_ENDPOINT}?timestamp=${timestamp}`);
+
+    return response.data.data;
+}
+
+const fetchADAprice = async (timestamp: number) => {
+    const price = await getPrices([CARDANO_COIN_ID], timestamp);
+
+    return price[CARDANO_COIN_ID].price;
+}
+
+const lovelaceToUSD = (lovelace: string, price: number) => {
+    const ada = Number(BigInt(lovelace) * BigInt(100) / BigInt(10 ** ADA_DECIMAL)) / 100
+
+    return (ada * price).toString();
+}
+
+const convertDataToUSD = (data: DanogoDimensions, price: number) => {
+    const convertedData: DanogoFees = {
+        dailyFees: lovelaceToUSD(data.dailyFeesAdaValue, price),
+        totalFees: lovelaceToUSD(data.totalFeesAdaValue, price),
+    };
+
+    return convertedData;
+}
+
+const fetchData = async (timestamp: number) => {
+    const dataPromise = fetchDanogoGatewayData(timestamp);
+    const adaPricePromise = fetchADAprice(timestamp);
+    const [data, adaPrice] = await Promise.all([dataPromise, adaPricePromise]);
+
+    return {
+        timestamp: timestamp,
+        ...convertDataToUSD(data, adaPrice)
+    };
+}
+
+const adapter: SimpleAdapter = {
+    adapter: {
+        cardano: {
+            fetch: fetchData,
+            start: async () => 0,
+            runAtCurrTime: false,
+        }
+    }
+};
+
+export default adapter;

--- a/fees/danogo/index.ts
+++ b/fees/danogo/index.ts
@@ -4,6 +4,7 @@ import fetchURL from "../../utils/fetchURL";
 import { DanogoDimensions, DanogoFees } from "./types";
 
 const DANOGO_GATEWAY_ENDPOINT = 'https://danogo-gateway.tekoapis.com/api/v1/defillama-dimensions';
+const DANOGO_START_TIMESTAMP = 1685404800 // 30/05/2023
 const CARDANO_COIN_ID = "coingecko:cardano";
 const ADA_DECIMAL = 6;
 
@@ -49,7 +50,7 @@ const adapter: SimpleAdapter = {
     adapter: {
         cardano: {
             fetch: fetchData,
-            start: async () => 0,
+            start: async () => DANOGO_START_TIMESTAMP,
             runAtCurrTime: false,
         }
     }

--- a/fees/danogo/types.ts
+++ b/fees/danogo/types.ts
@@ -1,0 +1,11 @@
+export type DanogoDimensions = {
+    dailyVolumeAdaValue: string,
+    totalVolumeAdaValue: string,
+    dailyFeesAdaValue: string,
+    totalFeesAdaValue: string
+}
+
+export type DanogoFees = {
+    dailyFees: string,
+    totalFees: string,
+}


### PR DESCRIPTION
Descriptions:
  - Create a new dexs adapter that calculate and return total volume and daily volume in USD
  - Create a new fees adapter that calculate and return total fees and daily fees in USD

Changes:
  - Dexs Adapter (`dexs/danogo/index.ts`):
    - Fetch Dimensions Data from Danogo Getway Production Endpoint
    - Fetch ADA USD Price from helper with COIN_ID = `coingecko:cardano`
    - Convert Volume Data from Lovelace to USD

  - Fess Adapter (`fess/danogo/index.ts`):
    - Fetch Dimensions Data from Danogo Getway Production Endpoint
    - Fetch ADA USD Price from helper with COIN_ID = `coingecko:cardano`
    - Convert Fess Data from Lovelace to USD

Tests:
![image](https://github.com/DefiLlama/dimension-adapters/assets/142006359/3fad0aaf-ed57-4598-8a50-af4dc0e90e76)